### PR TITLE
Implement more color components

### DIFF
--- a/code/src/ui/package.json
+++ b/code/src/ui/package.json
@@ -22,6 +22,7 @@
       "@types/uuid": "^8.3.4",
       "axios": "^0.26.1",
       "buffer": "^6.0.3",
+      "colord": "^2.9.3",
       "html-react-parser": "^1.4.8",
       "react": "18.2.0",
       "react-color": "^2.19.3",

--- a/code/src/ui/src/components/ComputedColorSwatch.tsx
+++ b/code/src/ui/src/components/ComputedColorSwatch.tsx
@@ -1,0 +1,73 @@
+import React, { useRef, useEffect, useState } from "react";
+import { colord } from "colord";
+
+interface Props {
+    // classname to use for background and on colors to display
+    //  to the user in this swatch.  E.g. ".primary-050-bg"
+    className: string;
+    label?: string;
+    showId?: boolean;
+    showDetails?: boolean;
+    style?: any;
+}
+
+export const ComputedColorSwatch: React.FC<Props> = ({className, label, style}) => {
+
+    const colorDisplayRef = useRef<HTMLDivElement>(null);
+
+    const [_backgroundColorHex, _setBackgroundColorHex] = useState<string>("");
+    const [_backgroundColorRGB, _setBackgroundColorRGB] = useState<string>("");
+    const [_onColor, _setOnColor] = useState<string>("");
+
+    useEffect(() => {
+        if (!className) return;
+        const displayDiv = colorDisplayRef.current;
+        if (!displayDiv) {
+            throw new Error("color swatch missing DOM information");
+        }
+        const cssObj = window.getComputedStyle(displayDiv, null);
+        const colorObj = processColorIntoHexRGB(cssObj.backgroundColor);
+        _setBackgroundColorHex(colorObj.hex);
+        _setBackgroundColorRGB(colorObj.RGB);
+        _setOnColor(cssObj.color);
+    }, [className])
+
+    const processColorIntoHexRGB = (color: string) : {hex: string, RGB: string} => {
+        let retArray = {hex: "", RGB: ""};
+        if (!color) return retArray;
+        const colorObj = colord(color);
+        if (colorObj) {
+            retArray.RGB = colorObj.toRgbString();
+            retArray.hex = colorObj.toHex();
+        }
+        return retArray;
+    }
+
+    if (className) {
+    return (
+        <div className="color-swatch" style={style}>
+            {label && <div className="small-semibold">{label}</div>}
+            <div ref={colorDisplayRef} className={`color-box ${className}`}>Aa</div>
+            <div>
+                <div className="small-semibold">Hex: </div>
+                <div className="color-title small">{_backgroundColorHex}</div>
+            </div>
+            <div>
+                <div className="small-semibold">RGB: </div>
+                <div className="color-title small">{_backgroundColorRGB}</div>
+            </div>
+            <div>
+                <div className="small-semibold">On-Color: </div>
+                <div className="color-title small">{_onColor}</div>
+            </div>
+        </div>
+    );
+
+    } else {
+
+    return (
+        <div>Missing ColorShade information</div>
+    );
+    
+    }
+}

--- a/code/src/ui/src/mui-a11y-tb/themes/Theme.css
+++ b/code/src/ui/src/mui-a11y-tb/themes/Theme.css
@@ -2739,6 +2739,9 @@ button.small-btn.MuiButton-text::before {
   background: var(--white) !important;
   color: var(--black) !important;
 }
+.white-half {
+  background: var(--white-half) !important;
+}
 .white button , .white-bg  button  {
   background: var(--buttonOnWhite) !important;
   color: var(--onbuttonOnWhite) !important;
@@ -2999,6 +3002,62 @@ button.small-btn.MuiButton-text::before {
 }
 .tertiary-900-bg path{
   fill: var(--on-tertiary-900);
+}
+
+.gray {
+  background: var(--gray) !important;
+  color: var(--on-gray) !important;
+}
+
+.gray-050-bg {
+  background: var(--gray-0) !important;
+  color: var(--on-gray-0);
+}
+.gray-100-bg {
+  background: var(--gray-100) !important;
+  color: var(--on-gray-100);
+}
+
+.gray-200-bg {
+  background: var(--gray-200) !important;
+  color: var(--on-gray-200);
+}
+.gray-300-bg {
+  background: var(--gray-300) !important;
+  color: var(--on-gray-300);
+}
+.gray-400-bg {
+  background: var(--gray-400) !important;
+  color: var(--on-gray-400);
+}
+.gray-500-bg {
+  background: var(--gray-500) !important;
+  color: var(--on-gray-500);
+}
+.gray-600-bg {
+  background: var(--gray-600) !important;
+  color: var(--on-gray-600);
+}
+.gray-700-bg {
+  background: var(--gray-700) !important;
+  color: var(--on-gray-700);
+}
+.gray-800-bg {
+  background: var(--gray-800) !important;
+  color: var(--on-gray-800);
+}
+.gray-900-bg {
+  background: var(--gray-900) !important;
+  color: var(--on-gray-900);
+}
+.nearblack-bg {
+  background: var(--nearblack) !important;
+  color: var(--on-nearblack);
+}
+
+.darkmode .nearblack-bg {
+  background: var(--nearblack) !important;
+  color: var(--dm-on-nearblack);
 }
 
 .background {

--- a/code/src/ui/src/mui-a11y-tb/themes/Theme.css
+++ b/code/src/ui/src/mui-a11y-tb/themes/Theme.css
@@ -2734,6 +2734,246 @@ button.small-btn.MuiButton-text::before {
   color: var(--hotlinkOnBlack);
 }
 
-/* .dropdownFocus {
-  margin-bottom: 200px;
-}*/
+.primary-050-bg {
+  background: var(--primary-0) !important;
+  color: var(--on-primary-0) !important;
+  fill: var(--primary-0) !important;
+}
+.primary-050-bg path{
+    fill: var(--on-primary-050) !important;
+}
+
+.primary-100-bg {
+  background: var(--primary-100)  !important;
+  color: var(--on-primary-100) !important;
+  fill: var(--primary-100)  !important;
+}
+.primary-100-bg path{
+    fill: var(--on-primary-100) !important;
+}
+
+.primary-200-bg {
+  background: var(--primary-200)  !important;
+  color: var(--on-primary-200) !important;
+  fill:var(--primary-200)  !important;
+}
+.primary-200-bg path{
+    fill: var(--on-primary-200) !important;
+}
+.primary-300-bg {
+  background: var(--primary-300)  !important;
+  color: var(--on-primary-300) !important;
+  fill: var(--primary-300)  !important;
+}
+.primary-300-bg path{
+    fill: var(--on-primary-300) !important;
+}
+.primary-400-bg {
+  background: var(--primary-400)  !important;
+  color: var(--on-primary-400) !important;
+  fill:  var(--primary-400)  !important;
+}
+.primary-400-bg path{
+    fill: var(--on-primary-400) !important;
+}
+.primary-500-bg {
+  background: var(--primary-500)  !important;
+  color: var(--on-primary-500) !important;
+  fill: var(--on-primary-500) !important;
+}
+.primary-500-bg path{
+    fill: var(--on-primary-500) !important;
+}
+.primary-600-bg {
+  background: var(--primary-600)  !important;
+  color: var(--on-primary-600) !important;
+  fill: var(--primary-600)  !important;
+}
+.primary-600-bg path{
+    fill: var(--on-primary-600);
+}
+.primary-700-bg {
+  background: var(--primary-700)  !important;
+  color: var(--on-primary-700) !important;
+  fill: var(--primary-700)  !important;
+}
+.primary-700-bg path{
+    fill: var(--on-primary-700);
+}
+.primary-800-bg, .primary-800 {
+  background: var(--primary-800)  !important;
+  color: var(--white) !important;
+  fill: var(--primary-800)  !important;
+}
+.primary-800-bg path{
+    fill: var(--on-primary-800);
+}
+.primary-900-bg, .primary-900 {
+  background: var(--primary-900)  !important;
+  color: var(--white) !important;
+  fill: var(--primary-900)  !important;
+}
+
+.primary-900-bg path{
+    fill: var(--on-primary-900);
+}
+.secondary {
+  background: var(--secondary) !important;
+  color: var(--on-secondary) !important;
+}
+.secondary-bg path{
+    fill: var(--on-secondary);
+}
+
+.secondary-050-bg {
+  background: var(--secondary-0)  !important;
+  color: var(--on-secondary-0) !important;
+}
+.secondary-050-bg path{
+    fill: var(--on-secondary-050);
+}
+.secondary-100-bg {
+  background: var(--secondary-100)  !important;
+  color: var(--on-secondary-100) !important;
+}
+.secondary-100-bg path{
+    fill: var(--on-secondary-100);
+}
+.secondary-200-bg {
+  background: var(--secondary-200)  !important;
+  color: var(--on-secondary-200) !important;
+}
+.secondary-200-bg path{
+    fill: var(--on-secondary-200);
+}
+.secondary-300-bg {
+  background: var(--secondary-300)  !important;
+  color: var(--on-secondary-300) !important;
+}
+.secondary-300-bg path{
+    fill: var(--on-secondary-300);
+}
+.secondary-400-bg {
+  background: var(--secondary-400)  !important;
+  color: var(--on-secondary-400) !important;
+}
+.secondary-400-bg path{
+    fill: var(--on-secondary-400);
+}
+.secondary400-bg path{
+    fill: var(--on-secondary-400) !important;
+}
+.secondary-500-bg {
+  background: var(--secondary-500)  !important;
+  color: var(--on-secondary-500) !important;
+}
+.secondary-500-bg path{
+    fill: var(--on-secondary-500);
+}
+.secondary-600-bg {
+  background: var(--secondary-600)  !important;
+  color: var(--on-secondary-600) !important;
+}
+.secondary-600-bg path{
+    fill: var(--on-secondary-600);
+}
+.secondary-700-bg {
+  background: var(--secondary-700)  !important;
+  color: var(--on-secondary-700) !important;
+}
+.secondary-700-bg path{
+    fill: var(--on-secondary-700);
+}
+.secondary-800-bg {
+  background: var(--secondary-800)  !important;
+  color: var(--on-secondary-800) !important;
+}
+.secondary-800-bg path{
+    fill: var(--on-secondary-800);
+}
+.secondary-900-bg {
+  background: var(--secondary-900)  !important;
+  color: var(--on-secondary-900) !important;
+}
+.secondary-900-bg path{
+    fill: var(--on-secondary-900);
+}
+.tertiary {
+  background: var(--tertiary) !important;
+  color: var(--on-tertiary) !important;
+}
+.tertiary-bg path{
+    fill: var(--on-tertiary);
+}
+
+.tertiary-050-bg {
+  background: var(--tertiary-0)  !important;
+  color: var(--on-tertiary-0);
+}
+.tertiary-050-bg path{
+    fill: var(--on-tertiary-050);
+}
+
+.tertiary-100-bg {
+  background: var(--tertiary-100)  !important;
+  color: var(--on-tertiary-100);
+}
+.tertiary-100-bg path{
+    fill: var(--on-tertiary-100);
+}
+.tertiary-200-bg {
+  background: var(--tertiary-200)  !important;
+  color: var(--on-tertiary-200);
+}
+.tertiary-200-bg path{
+    fill: var(--on-tertiary-200);
+}
+.tertiary-300-bg {
+  background: var(--tertiary-300)  !important;
+  color: var(--on-tertiary-300);
+}
+.tertiary-300-bg path{
+    fill: var(--on-tertiary-300);
+}
+.tertiary-400-bg {
+  background: var(--tertiary-400)  !important;
+  color: var(--on-tertiary-400);
+}
+.tertiary-400-bg path{
+    fill: var(--on-tertiary-400);
+}
+.tertiary-500-bg {
+  background: var(--tertiary-500)  !important;
+  color: var(--on-tertiary-500);
+}
+.tertiary-500-bg path{
+    fill: var(--on-tertiary-500);
+}
+.tertiary-600-bg {
+  background: var(--tertiary-600)  !important;
+  color: var(--on-tertiary-600);
+}
+.tertiary-600-bg path{
+    fill: var(--on-tertiary-600);
+}
+.tertiary-700-bg {
+  background: var(--tertiary-700)  !important;
+  color: var(--on-tertiary-700);
+}
+.tertiary-700-bg path{
+    fill: var(--on-tertiary-700);
+}
+.tertiary-800-bg {
+  background: var(--tertiary-800)  !important;
+  color: var(--on-tertiary-800);
+}
+.tertiary-800-bg path{
+    fill: var(--on-tertiary-800);
+}
+.tertiary-900-bg {
+  background: var(--tertiary-900)  !important;
+  color: var(--on-tertiary-900);
+}
+.tertiary-900-bg path{
+  fill: var(--on-tertiary-900);
+}

--- a/code/src/ui/src/mui-a11y-tb/themes/Theme.css
+++ b/code/src/ui/src/mui-a11y-tb/themes/Theme.css
@@ -2734,6 +2734,29 @@ button.small-btn.MuiButton-text::before {
   color: var(--hotlinkOnBlack);
 }
 
+/*  WHITE  */
+.white , .white-bg {
+  background: var(--white) !important;
+  color: var(--black) !important;
+}
+.white button , .white-bg  button  {
+  background: var(--buttonOnWhite) !important;
+  color: var(--onbuttonOnWhite) !important;
+}
+.white button::after, .white-bg  button::after  {
+  border: calc(var(--border-1) * var(--button-border)) solid var(--buttonOnWhite);
+}
+.white button .inline-icon path, .white-bg button .inline-icon path {
+  fill: var(--onbuttonOnWhite) !important;
+}
+.white .inline-icon path , .white-bg .inline-icon path {
+  fill: var(--iconOnWhite) !important;
+}
+.white a , .white-bg a {
+  text-decoration: var(--linkDecorationOnWhite);
+  color: var(--linkOnWhite);
+}
+
 .primary-050-bg {
   background: var(--primary-0) !important;
   color: var(--on-primary-0) !important;
@@ -2976,4 +2999,34 @@ button.small-btn.MuiButton-text::before {
 }
 .tertiary-900-bg path{
   fill: var(--on-tertiary-900);
+}
+
+.background {
+  background: var(--background) !important;
+  color: var(--on-background);
+}
+/*.background:nth-of-type(even), .background-secondary  {*/
+.background-secondary  {
+  background: var(--background-secondary) !important;
+  color: var(--on-background-secondary);
+}
+
+.background-tertiary  {
+  background: var(--background-tertiary) !important;
+  color: var(--on-background-tertiary);
+}
+
+.darkmode .background, .darkmode.background {
+  background: var(--dm-background) !important;
+  color: var(--dm-on-background);
+}
+
+.darkmode .background:nth-of-type(even), .darkmode .background-secondary{
+  background: var(--dm-background-secondary) !important;
+  color: var(--dm-on-background-secondary);
+}
+
+.darkmode .background-tertiary {
+  background: var(--dm-background-tertiary) !important;
+  color: var(--dm-on-background-tertiary);
 }

--- a/code/src/ui/src/mui-a11y-tb/themes/Theme.css
+++ b/code/src/ui/src/mui-a11y-tb/themes/Theme.css
@@ -3050,6 +3050,50 @@ button.small-btn.MuiButton-text::before {
   background: var(--gray-900) !important;
   color: var(--on-gray-900);
 }
+
+/* States */
+.info {
+  background: var(--info) !important;
+  color: var(--on-info);
+  fill: rgb(var(--info));
+}
+.success {
+  background: var(--success) !important;
+  color: var(--on-success );
+  fill: rgb(var(--success));
+}
+.warning {
+  background: var(--warning) !important;
+  color: var(--on-warning);
+  fill: rgb(var(--warning));
+}
+.danger {
+  background: var(--danger) !important;
+  color: var(--on-danger);
+  fill: rgb(var(--danger)) !important;
+}
+
+.darkmode .info {
+  background: var(--dm-info) !important;
+  color: var(--dm-on-info);
+  fill: rgb(var(--dm-info));
+}
+.darkmode .success {
+  background: var(--dm-success) !important;
+  color: var(--dm-on-success );
+  fill: rgb(var(--dm-success));
+}
+.darkmode .warning {
+  background: var(--dm-warning) !important;
+  color: var(--dm-on-warning);
+  fill: rgb(var(--dm-warning));
+}
+.darkmode .danger {
+  background: var(--dm-danger) !important;
+  color: var(--dm-on-danger);
+  fill: rgb(var(--dm-danger)) !important;
+}
+
 .nearblack-bg {
   background: var(--nearblack) !important;
   color: var(--on-nearblack);

--- a/code/src/ui/src/pages/atoms/StatesAtom.css
+++ b/code/src/ui/src/pages/atoms/StatesAtom.css
@@ -13,48 +13,6 @@
     margin-top: 21px;
 }
 
-.design-system-editor-right-content .information {
-    background: var(--info) !important;
-    color: var(--on-info);
-    fill: rgb(var(--info));
-}
-.design-system-editor-right-content .success {
-    background: var(--success) !important;
-    color: var(--on-success );
-    fill: rgb(var(--success));
-}
-.design-system-editor-right-content .warning {
-    background: var(--warning) !important;
-    color: var(--on-warning);
-    fill: rgb(var(--warning));
-}
-.design-system-editor-right-content .danger{
-    background: var(--danger) !important;
-    color: var(--on-danger);
-    fill: rgb(var(--danger)) !important;
-}
-
-.design-system-editor-right-content .darkmode .information {
-    background: var(--dm-info) !important;
-    color: var(--dm-on-info);
-    fill: rgb(var(--dm-info));
-}
-.design-system-editor-right-content .darkmode .success {
-    background: var(--dm-success) !important;
-    color: var(--dm-on-success );
-    fill: rgb(var(--dm-success));
-}
-.design-system-editor-right-content .darkmode .warning {
-    background: var(--dm-warning) !important;
-    color: var(--dm-on-warning);
-    fill: rgb(var(--dm-warning));
-}
-.design-system-editor-right-content .darkmode .danger {
-    background: var(--dm-danger) !important;
-    color: var(--dm-on-danger);
-    fill: rgb(var(--dm-danger)) !important;
-}
-
 .design-system-editor-right-content .darkmode .statesListItem input {
     background: var(--dm-background) !important;
     color: var(--dm-on-background);

--- a/code/src/ui/src/pages/components/colors/BackgroundColorsComponent.tsx
+++ b/code/src/ui/src/pages/components/colors/BackgroundColorsComponent.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { HeadingSection } from '../../content/HeadingSection';
+import { ComputedColorSwatch } from '../../../components/ComputedColorSwatch';
+
+interface Props {
+}
+
+const swatchesObj = {
+    labels: ["Primary", "Secondary", "Tertiary"],
+    shadeIds: ["050", "100", "200", "300", "400", "500", "600", "700", "800", "900"],
+    classNameSuffix: "bg",
+}
+
+export const BackgroundColorsComponent: React.FC<Props> = ({}) => {
+
+    return (
+        <div>
+            <HeadingSection title="Colors" heading="Background Colors" />
+            <div>
+                <div className="theme-colors">
+                    <ComputedColorSwatch
+                        className={"background"}
+                        label={"Primary BG"}
+                    />
+                    <ComputedColorSwatch
+                        className={"background-secondary"}
+                        label={"Secondary BG"}
+                    />
+                    <ComputedColorSwatch
+                        className={"background-tertiary"}
+                        label={"Tertiary BG"}
+                    />
+                    <ComputedColorSwatch
+                        className={"black"}
+                        label={"Black BG"}
+                    />
+                    <ComputedColorSwatch
+                        className={"white"}
+                        label={"White BG"}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/code/src/ui/src/pages/components/colors/BackgroundColorsComponent.tsx
+++ b/code/src/ui/src/pages/components/colors/BackgroundColorsComponent.tsx
@@ -5,12 +5,6 @@ import { ComputedColorSwatch } from '../../../components/ComputedColorSwatch';
 interface Props {
 }
 
-const swatchesObj = {
-    labels: ["Primary", "Secondary", "Tertiary"],
-    shadeIds: ["050", "100", "200", "300", "400", "500", "600", "700", "800", "900"],
-    classNameSuffix: "bg",
-}
-
 export const BackgroundColorsComponent: React.FC<Props> = ({}) => {
 
     return (

--- a/code/src/ui/src/pages/components/colors/ColorStatesComponent.tsx
+++ b/code/src/ui/src/pages/components/colors/ColorStatesComponent.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { DesignSystem, StateSettings } from 'a11y-theme-builder-sdk';
 import { HeadingSection } from '../../content/HeadingSection';
-import { ColorSwatch } from '../../../components/ColorSwatch';
+import { ComputedColorSwatch } from '../../../components/ComputedColorSwatch';
 
 interface Props {
     designSystem: DesignSystem;
@@ -16,10 +16,22 @@ export const ColorStatesComponent: React.FC<Props> = ({designSystem}) => {
             <div>
                 <HeadingSection title="Colors" heading="State Colors" />
                 <div className="theme-colors">
-                    <ColorSwatch shade={_stateSettings.info.lmShade}></ColorSwatch>
-                    <ColorSwatch shade={_stateSettings.success.lmShade}></ColorSwatch>
-                    <ColorSwatch shade={_stateSettings.warning.lmShade}></ColorSwatch>
-                    <ColorSwatch shade={_stateSettings.danger.lmShade}></ColorSwatch>
+                    <ComputedColorSwatch
+                        className="info"
+                        label="Info"
+                    />
+                    <ComputedColorSwatch
+                        className="success"
+                        label="Success"
+                    />
+                    <ComputedColorSwatch
+                        className="warning"
+                        label="Warning"
+                    />
+                    <ComputedColorSwatch
+                        className="danger"
+                        label="Danger"
+                    />
                 </div>
             </div>
         );

--- a/code/src/ui/src/pages/components/colors/CoreColorsComponent.tsx
+++ b/code/src/ui/src/pages/components/colors/CoreColorsComponent.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { HeadingSection } from '../../content/HeadingSection';
+import { ComputedColorSwatch } from '../../../components/ComputedColorSwatch';
+
+interface Props {
+}
+
+const swatchesObj = {
+    labels: ["Gray"],
+    shadeIds: ["050", "100", "200", "300", "400", "500", "600", "700", "800", "900"],
+    classNameSuffix: "bg",
+}
+
+export const CoreColorsComponent: React.FC<Props> = ({}) => {
+
+    return (
+        <div>
+            <HeadingSection title="Colors" heading="Core Colors" />
+            <div>
+                <div className="subtitle1 top40">White</div>
+                <div className="theme-colors">
+                    <ComputedColorSwatch
+                        className="white"
+                        label="White"
+                    />
+                    <ComputedColorSwatch
+                        className="white-half"
+                        label="White Half"
+                    />
+                </div>
+                <div className="subtitle1 top40">Black</div>
+                <div className="theme-colors">
+                    <ComputedColorSwatch
+                        className="black"
+                        label="Black"
+                    />
+                    <ComputedColorSwatch
+                        className="black-half"
+                        label="Black Half"
+                    />
+                </div>
+                <div className="subtitle1 top40">Near Black</div>
+                <div className="theme-colors">
+                    <ComputedColorSwatch
+                        className="nearblack-bg"
+                        label="Near Black"
+                    />
+                </div>
+            </div>
+            {swatchesObj.labels.map((swatchLabel) => {
+                return (
+                    <div>
+                        <div className="subtitle1 top40">{swatchLabel}</div>
+                        <div className="theme-colors">
+                            {swatchesObj.shadeIds.map((shadeId) => {
+                                return (
+                                    <ComputedColorSwatch
+                                        className={`${swatchLabel.toLowerCase()}-${shadeId}-${swatchesObj.classNameSuffix}`}
+                                        label={`${swatchLabel}-${shadeId}`}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/code/src/ui/src/pages/components/colors/ThemeColorsComponent.tsx
+++ b/code/src/ui/src/pages/components/colors/ThemeColorsComponent.tsx
@@ -1,10 +1,8 @@
-import React, { useState } from 'react';
-import { Color, ColorPalette, DesignSystem } from 'a11y-theme-builder-sdk';
+import React from 'react';
 import { HeadingSection } from '../../content/HeadingSection';
 import { ComputedColorSwatch } from '../../../components/ComputedColorSwatch';
 
 interface Props {
-    designSystem: DesignSystem;
 }
 
 const swatchesObj = {
@@ -13,7 +11,7 @@ const swatchesObj = {
     classNameSuffix: "bg",
 }
 
-export const ThemeColorsComponent: React.FC<Props> = ({designSystem}) => {
+export const ThemeColorsComponent: React.FC<Props> = ({}) => {
 
     return (
         <div>

--- a/code/src/ui/src/pages/components/colors/ThemeColorsComponent.tsx
+++ b/code/src/ui/src/pages/components/colors/ThemeColorsComponent.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Color, ColorPalette, DesignSystem } from 'a11y-theme-builder-sdk';
+import { HeadingSection } from '../../content/HeadingSection';
+import { ComputedColorSwatch } from '../../../components/ComputedColorSwatch';
+
+interface Props {
+    designSystem: DesignSystem;
+}
+
+const swatchesObj = {
+    labels: ["Primary", "Secondary", "Tertiary"],
+    shadeIds: ["050", "100", "200", "300", "400", "500", "600", "700", "800", "900"],
+    classNameSuffix: "bg",
+}
+
+export const ThemeColorsComponent: React.FC<Props> = ({designSystem}) => {
+
+    return (
+        <div>
+            <HeadingSection title="Colors" heading="Theme Colors" />
+            {swatchesObj.labels.map((swatchLabel) => {
+                return (
+                    <div>
+                        <div className="subtitle1 top40">{swatchLabel}</div>
+                        <div className="theme-colors">
+                            {swatchesObj.shadeIds.map((shadeId) => {
+                                return (
+                                    <ComputedColorSwatch
+                                        className={`${swatchLabel.toLowerCase()}-${shadeId}-${swatchesObj.classNameSuffix}`}
+                                        label={`${swatchLabel}-${shadeId}`}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/code/src/ui/src/pages/content/components/ComponentsContent.tsx
+++ b/code/src/ui/src/pages/content/components/ComponentsContent.tsx
@@ -24,6 +24,7 @@ import { ToastsTripleLineComponent } from '../../components/ToastsTripleLineComp
 import { SwitchComponent } from '../../components/SwitchComponent';
 import { RadioButtonsComponent } from '../../components/RadioButtonsComponent';
 import { PopoversComponent } from '../../components/PopoversComponent';
+import { CoreColorsComponent } from '../../components/colors/CoreColorsComponent';
 import { ThemeColorsComponent } from '../../components/colors/ThemeColorsComponent';
 import { ExtendedPaletteComponent } from '../../components/colors/ExtendedPaletteComponent';
 import { BackgroundColorsComponent } from '../../components/colors/BackgroundColorsComponent';
@@ -91,6 +92,7 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
                     </LeftNavItem>
                     <Collapse in={displayColors} timeout="auto" unmountOnExit>
                         <List component="div" disablePadding>
+                        <LeftNavItem text={"Core Colors"} value="colorsCoreColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsCoreColors")}} />
                             <LeftNavItem text={"Theme Colors"} value="colorsThemeColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsThemeColors")}} />
                             <LeftNavItem text={"Extended Palette"} value="colorsExtendedPalette" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsExtendedPalette")}} />
                             <LeftNavItem text={"Background Colors"} value="colorsBackgroundColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsBackgroundColors")}} />
@@ -170,6 +172,9 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
             </div>
             <div className="design-system-editor-right-content">
             <div className="design-system-editor-right-content-scrollable">
+                    {showComponent === "colorsCoreColors" &&
+                        <CoreColorsComponent />
+                    }
                     {showComponent === "colorsThemeColors" &&
                         <ThemeColorsComponent />
                     }

--- a/code/src/ui/src/pages/content/components/ComponentsContent.tsx
+++ b/code/src/ui/src/pages/content/components/ComponentsContent.tsx
@@ -95,7 +95,7 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
                         <LeftNavItem text={"Core Colors"} value="colorsCoreColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsCoreColors")}} />
                             <LeftNavItem text={"Theme Colors"} value="colorsThemeColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsThemeColors")}} />
                             <LeftNavItem text={"Extended Palette"} value="colorsExtendedPalette" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsExtendedPalette")}} />
-                            <LeftNavItem text={"Background Colors"} value="colorsBackgroundColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsBackgroundColors")}} />
+                            <LeftNavItem text={"Backgrounds"} value="colorsBackgroundColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsBackgroundColors")}} />
                             <LeftNavItem text={"Gradients"} value="colorsGradients" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsGradients")}} />
                             <LeftNavItem text={"States"} value="colorsStates" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsStates")}} />
                         </List>

--- a/code/src/ui/src/pages/content/components/ComponentsContent.tsx
+++ b/code/src/ui/src/pages/content/components/ComponentsContent.tsx
@@ -24,6 +24,7 @@ import { ToastsTripleLineComponent } from '../../components/ToastsTripleLineComp
 import { SwitchComponent } from '../../components/SwitchComponent';
 import { RadioButtonsComponent } from '../../components/RadioButtonsComponent';
 import { PopoversComponent } from '../../components/PopoversComponent';
+import { ThemeColorsComponent } from '../../components/colors/ThemeColorsComponent';
 import { ExtendedPaletteComponent } from '../../components/colors/ExtendedPaletteComponent';
 import { GradientsComponent } from '../../components/colors/GradientsComponent';
 import { ColorStatesComponent } from '../../components/colors/ColorStatesComponent';
@@ -89,7 +90,7 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
                     </LeftNavItem>
                     <Collapse in={displayColors} timeout="auto" unmountOnExit>
                         <List component="div" disablePadding>
-                            <LeftNavItem text={"Primary"} value="colorsPrimary" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsPrimary")}} />
+                            <LeftNavItem text={"Theme Colors"} value="colorsThemeColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsThemeColors")}} />
                             <LeftNavItem text={"Extended Palette"} value="colorsExtendedPalette" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsExtendedPalette")}} />
                             <LeftNavItem text={"Gradients"} value="colorsGradients" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsGradients")}} />
                             <LeftNavItem text={"States"} value="colorsStates" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsStates")}} />
@@ -167,6 +168,9 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
             </div>
             <div className="design-system-editor-right-content">
             <div className="design-system-editor-right-content-scrollable">
+                    {showComponent === "colorsThemeColors" &&
+                        <ThemeColorsComponent designSystem={designSystem} />
+                    }
                     {showComponent === "colorsExtendedPalette" &&
                         <ExtendedPaletteComponent designSystem={designSystem} />
                     }

--- a/code/src/ui/src/pages/content/components/ComponentsContent.tsx
+++ b/code/src/ui/src/pages/content/components/ComponentsContent.tsx
@@ -26,6 +26,7 @@ import { RadioButtonsComponent } from '../../components/RadioButtonsComponent';
 import { PopoversComponent } from '../../components/PopoversComponent';
 import { ThemeColorsComponent } from '../../components/colors/ThemeColorsComponent';
 import { ExtendedPaletteComponent } from '../../components/colors/ExtendedPaletteComponent';
+import { BackgroundColorsComponent } from '../../components/colors/BackgroundColorsComponent';
 import { GradientsComponent } from '../../components/colors/GradientsComponent';
 import { ColorStatesComponent } from '../../components/colors/ColorStatesComponent';
 import { PrimaryTabsComponent } from '../../components/PrimaryTabsComponent';
@@ -92,6 +93,7 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
                         <List component="div" disablePadding>
                             <LeftNavItem text={"Theme Colors"} value="colorsThemeColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsThemeColors")}} />
                             <LeftNavItem text={"Extended Palette"} value="colorsExtendedPalette" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsExtendedPalette")}} />
+                            <LeftNavItem text={"Background Colors"} value="colorsBackgroundColors" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsBackgroundColors")}} />
                             <LeftNavItem text={"Gradients"} value="colorsGradients" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsGradients")}} />
                             <LeftNavItem text={"States"} value="colorsStates" indent={2} selected={showComponent} onClick={()=> {setShowComponent("colorsStates")}} />
                         </List>
@@ -169,10 +171,13 @@ export const ComponentsContent: React.FC<Props> = ({ user, designSystem }) => {
             <div className="design-system-editor-right-content">
             <div className="design-system-editor-right-content-scrollable">
                     {showComponent === "colorsThemeColors" &&
-                        <ThemeColorsComponent designSystem={designSystem} />
+                        <ThemeColorsComponent />
                     }
                     {showComponent === "colorsExtendedPalette" &&
                         <ExtendedPaletteComponent designSystem={designSystem} />
+                    }
+                    {showComponent === "colorsBackgroundColors" &&
+                        <BackgroundColorsComponent />
                     }
                     {showComponent === "colorsGradients" &&
                         <GradientsComponent />


### PR DESCRIPTION
I added ComputedSwatchComponent that will pull the example color from CSS var using className on the div and then using useRef and getComputedStyle on the div DOM element, I pull the background and foreground ("on") color information and display those in the details for the swatch.  So all of the information is coming from CSS and not the SDK.

I added implementations for the pages:
- Core Colors
- Theme Colors
- Backgrounds

I fixed the States Colors page to use the new ComputedSwatchComponent.

I added a lot of styles to Theme.css that Lise was using to populate these swatches.