### PR TITLE
Fix Popovers Molecule Settings

### DIFF
--- a/code/src/ui/src/pages/atoms/BevelsAtom.tsx
+++ b/code/src/ui/src/pages/atoms/BevelsAtom.tsx
@@ -43,7 +43,7 @@ export const BevelsAtom: React.FC<Props> = ({ bevelSettings }) => {
     const [spreadRadius,           setSpreadRadius          ] = useState<number>(spreadRadiusProperty.getValue()           || 0);
     const [lightGlowOpacity,       setLightGlowOpacity      ] = useState<number>(lightGlowOpacityProperty.getValue()       || 0);
     const [darkShadowOpacity,      setDarkShadowOpacity     ] = useState<number>(darkShadowOpacityProperty.getValue()      || 0);
-    const [percentChange,          sertPercentChange        ] = useState<number>(percentChangeProperty.getValue()          || 0);
+    const [percentChange,          setPercentChange         ] = useState<number>(percentChangeProperty.getValue()          || 0);
 
     async function handleHorizontalShadowLengthChange(event: any): Promise<void> {
         const value = Number(event.target.value);
@@ -77,7 +77,7 @@ export const BevelsAtom: React.FC<Props> = ({ bevelSettings }) => {
     }
     async function handlePercentChangeChange(event: any): Promise<void> {
         const value = Number(event.target.value);
-        sertPercentChange(value);
+        setPercentChange(value);
         percentChangeProperty.setValue(value)
     }
 
@@ -95,7 +95,7 @@ export const BevelsAtom: React.FC<Props> = ({ bevelSettings }) => {
     const [inverseSpreadRadius,           setInverseSpreadRadius          ] = useState<number>(inverseSpreadRadiusProperty.getValue()           || 0);
     const [inverseLightGlowOpacity,       setInverseLightGlowOpacity      ] = useState<number>(inverseLightGlowOpacityProperty.getValue()       || 0);
     const [inverseDarkShadowOpacity,      setInverseDarkShadowOpacity     ] = useState<number>(inverseDarkShadowOpacityProperty.getValue()      || 0);
-    const [inversePercentChange,          sertInversePercentChange        ] = useState<number>(inversePercentChangeProperty.getValue()          || 0);
+    const [inversePercentChange,          setInversePercentChange        ] = useState<number>(inversePercentChangeProperty.getValue()          || 0);
 
     async function handleInverseHorizontalShadowLengthChange(event: any): Promise<void> {
         const value = Number(event.target.value);
@@ -129,7 +129,7 @@ export const BevelsAtom: React.FC<Props> = ({ bevelSettings }) => {
     }
     async function handleInversePercentChangeChange(event: any): Promise<void> {
         const value = Number(event.target.value);
-        sertInversePercentChange(value);
+        setInversePercentChange(value);
         inversePercentChangeProperty.setValue(value)
     }
 
@@ -311,6 +311,20 @@ export const BevelsAtom: React.FC<Props> = ({ bevelSettings }) => {
                                 valueLabelDisplay="auto"
                                 min={inverseSpreadRadiusProperty.min}
                                 max={inverseSpreadRadiusProperty.max}
+                            />
+                        </div>
+                        <div className="form-row">
+                            <label className="label-1">
+                                Spread Radius
+                            </label>
+                            <Slider
+                                aria-label="InverseLightGlowOpacity"
+                                value={inverseLightGlowOpacity}
+                                sx={{maxWidth:600}}
+                                onChange={handleInverseLightGlowOpacityChange}
+                                valueLabelDisplay="auto"
+                                min={inverseLightGlowOpacityProperty.min}
+                                max={inverseLightGlowOpacityProperty.max}
                             />
                         </div>
                         <div className="form-row">

--- a/code/src/ui/src/pages/atoms/ElevationsAtom.tsx
+++ b/code/src/ui/src/pages/atoms/ElevationsAtom.tsx
@@ -2,9 +2,9 @@
  * Copyright (c) 2023 Discover Financial Services
  * Licensed under MIT License. See License.txt in the project root for license information
  */
-import React, { useState, useEffect, ChangeEvent } from 'react';
-import { MenuItem, Select, FormControl, InputLabel, TextField, Slider } from '@mui/material';
-import { DesignSystem, ElevationSettings } from 'a11y-theme-builder-sdk';
+import React, { useState } from 'react';
+import { InputLabel, TextField, Slider } from '@mui/material';
+import { ElevationSettings } from 'a11y-theme-builder-sdk';
 //import { ExampleElevation } from '../../components/ExampleElevation';
 import { ChromePicker, ColorResult } from 'react-color';
 import { HeadingSection } from '../content/HeadingSection';
@@ -55,7 +55,7 @@ export const ElevationsAtom: React.FC<Props> = ({ elevationSettings }) => {
     const [blurRadius,             setBlurRadius            ] = useState<number>(blurRadiusProperty.getValue()             || 0);
     const [spreadRadius,           setSpreadRadius          ] = useState<number>(spreadRadiusProperty.getValue()           || 0);
     const [colorOpacity,           setColorOpacity          ] = useState<number>(colorOpacityProperty.getValue()           || 0);
-    const [percentChange,          sertPercentChange        ] = useState<number>(percentChangeProperty.getValue()          || 0);
+    const [percentChange,          setPercentChange         ] = useState<number>(percentChangeProperty.getValue()          || 0);
 
     const handleShadowColorChange = (event: any) => {
         if (!/^#[0-9A-F]{6}$/i.test(event.target.value) == true) {
@@ -113,7 +113,7 @@ export const ElevationsAtom: React.FC<Props> = ({ elevationSettings }) => {
     }
     async function handlePercentChangeChange(event: any): Promise<void> {
         const value = Number(event.target.value);
-        sertPercentChange(value);
+        setPercentChange(value);
         percentChangeProperty.setValue(value)
     }
 

--- a/code/src/ui/src/pages/molecules/PopoversMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/PopoversMolecule.tsx
@@ -28,9 +28,11 @@ export const PopoversMolecule: React.FC<Props> = ({ popoversMolecule, designSyst
         setAnchor(null)
     }
 
-    const boxShadowString = (popoversMolecule.elevation.getValue() === "No Elevation") 
-        ? "none" 
-        : "var(--" + popoversMolecule.elevation.getValue()?.toLowerCase() +") !important"
+    let noElevation = popoversMolecule.elevation.getValue() === "No Elevation"
+    let elevationBoxShadowString = noElevation ? "none" : "var(--" + popoversMolecule.elevation.getValue()?.toLowerCase() +") !important"
+    
+    let noBevel = popoversMolecule.bevel.getValue() === "No Bevel"
+    let bevelBoxShadowString = noBevel ? "none" : "var(--" + popoversMolecule.bevel.getValue()?.toLowerCase() +") !important"
 
     return (
         <div>
@@ -55,7 +57,7 @@ export const PopoversMolecule: React.FC<Props> = ({ popoversMolecule, designSyst
                     PaperProps={{
                         sx: {
                             borderRadius: "calc(var(--popoverRadius) * var(--radius-1))",
-                            boxShadow: boxShadowString
+                            boxShadow: noElevation ? bevelBoxShadowString : elevationBoxShadowString
                         }
                     }}
                 >

--- a/code/src/ui/src/pages/molecules/PopoversMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/PopoversMolecule.tsx
@@ -28,6 +28,10 @@ export const PopoversMolecule: React.FC<Props> = ({ popoversMolecule, designSyst
         setAnchor(null)
     }
 
+    const boxShadowString = (popoversMolecule.elevation.getValue() === "No Elevation") 
+        ? "none" 
+        : "var(--" + popoversMolecule.elevation.getValue()?.toLowerCase() +") !important"
+
     return (
         <div>
             <HeadingSection item={popoversMolecule} title="Apply Styles"></HeadingSection>
@@ -51,6 +55,7 @@ export const PopoversMolecule: React.FC<Props> = ({ popoversMolecule, designSyst
                     PaperProps={{
                         sx: {
                             borderRadius: "calc(var(--popoverRadius) * var(--radius-1))",
+                            boxShadow: boxShadowString
                         }
                     }}
                 >


### PR DESCRIPTION
https://github.com/discoverfinancial/a11y-theme-builder/issues/144
- changing elevation settings now changes the elevation on the popover
- changing bevel settings now changes the bevel on the popover
- if both elevation and bevel is set use the elevation setting