### PR TITLE
discoverfinancial/a11y-theme-builder#248

### DIFF
--- a/code/src/ui/src/components/modals/ModalConfirmation.tsx
+++ b/code/src/ui/src/components/modals/ModalConfirmation.tsx
@@ -36,8 +36,8 @@ const ModalConfirmation: React.FC<Props> = ({ title, isOpen, onClose, children }
                         {children}
                     </div>
                     <div className="modal-footer" style={{ display: "flex", gap:"var(--spacing-2)" }}>
-                        <Button className="MuiButton-outlined" onClick={handleCancel}>Cancel</Button>
                         <Button onClick={handleSubmit}>OK</Button>
+                        <Button className="MuiButton-outlined" onClick={handleCancel}>Cancel</Button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixed the button order on the ModalConfirmation dialog so that the OK button (primary button) is on the left and the Cancel button (secondary button) is on the right.