### PR TITLE
Propagate Primary/Secondary Font Change to All Text Styles

### DIFF
--- a/code/src/ui/src/components/modals/ModalFontEdit.tsx
+++ b/code/src/ui/src/components/modals/ModalFontEdit.tsx
@@ -14,6 +14,9 @@ import { SettingsSection } from '../../pages/content/SettingsSection';
 
 const name = "ModalFontEdit";
 
+const PRIMARY_PREFIX    = "Primary Font: "
+const SECONDARY_PREFIX  = "Secondary Font: "
+
 interface Props {
     isOpen: any;
     onCancel: any;
@@ -47,6 +50,8 @@ const ModalFontEdit: React.FC<Props> = ({isOpen, onCancel, designSystem, textKey
     const primaryFont   = designSystem.atoms.fontsSettings.primaryFont.getValue()   || "Open Sans";
     const secondaryFont = designSystem.atoms.fontsSettings.secondaryFont.getValue() || "Open Sans";
     const defaultFont   = isHeader ? secondaryFont : primaryFont;
+    const primaryFontWithPrefix = PRIMARY_PREFIX + primaryFont
+    const secondaryFontWithPrefix = SECONDARY_PREFIX + secondaryFont
 
     const fontFamilyProperty    = typographyStyling.fontFamily
     const fontSizeProperty      = typographyStyling.fontSize
@@ -57,6 +62,9 @@ const ModalFontEdit: React.FC<Props> = ({isOpen, onCancel, designSystem, textKey
     const [fontSize,    setFontSize   ] = useState<number>(fontSizeProperty.getValue()       || 16);
     const [fontWeight,  setFontWeight ] = useState<number>(fontWeightProperty.getValue()     || defaultWeight);
     const [charSpacing, setCharSpacing] = useState<number>(charSpacingProperty.getValue()    || 0);
+
+    const [fontFamilyWithPrefix, setFontFamilyWithPrefix ] = useState<string>(fontFamily === primaryFont 
+                                                            ? primaryFontWithPrefix : secondaryFontWithPrefix);
 
     const [fontUncommon, setFontUncommon] = useState<boolean>(!FontWeightsUtil.isFontCommon(fontFamily))
     const [fontWeightWarningTriggered, setFontWeightWarningTriggered] = useState<boolean>(false)
@@ -104,7 +112,9 @@ const ModalFontEdit: React.FC<Props> = ({isOpen, onCancel, designSystem, textKey
 
     async function handleFontFamilyChanged(event: any): Promise<void> {
         const value = event.target.value;
-        setFontFamily(value);
+        setFontFamilyWithPrefix(value)
+        const fontValue = value.split(": ")[1]
+        setFontFamily(fontValue);
     }
     async function handleFontSizeChange(event: any): Promise<void> {
         const value = parseInt(event.target.value);
@@ -135,12 +145,16 @@ const ModalFontEdit: React.FC<Props> = ({isOpen, onCancel, designSystem, textKey
                 <InputLabel id='fontFamilyLabel'>
                     {fontFamilyProperty.name}
                 </InputLabel>
-                <Select labelId='fontFamilyLabel' value={fontFamily} onChange={handleFontFamilyChanged}>
-                    <MenuItem key={"1"+primaryFont}   value={primaryFont}>
-                        <b>{"Primary Font: "+primaryFont}</b>
+                <Select
+                    labelId='fontFamilyLabel'  
+                    value={fontFamilyWithPrefix}
+                    onChange={handleFontFamilyChanged}
+                >
+                    <MenuItem key={primaryFontWithPrefix}   value={primaryFontWithPrefix}>
+                        <b>{primaryFontWithPrefix}</b>
                     </MenuItem>
-                    <MenuItem key={"2"+secondaryFont} value={secondaryFont}>
-                        <b>{"Secondary Font: "+secondaryFont}</b>
+                    <MenuItem key={secondaryFontWithPrefix} value={secondaryFontWithPrefix}>
+                        <b>{secondaryFontWithPrefix}</b>
                     </MenuItem>
                 </Select>
             </FormControl>

--- a/code/src/ui/src/pages/atoms/typography/FontSettingsAtom.tsx
+++ b/code/src/ui/src/pages/atoms/typography/FontSettingsAtom.tsx
@@ -177,6 +177,32 @@ export const FontSettingsAtom: React.FC<Props> = ({ atoms }) => {
         const value = event.target.value;
         setPrimaryFont(value);
         primaryFontFamilyProperty.setValue(value);
+
+        // Update all Body and Small Text Styles Fonts:
+        atoms.bodyStyles.body1.fontFamily.setValue                  (value ? value : undefined)
+        atoms.bodyStyles.body1Bold.fontFamily.setValue              (value ? value : undefined)
+        atoms.bodyStyles.body2.fontFamily.setValue                  (value ? value : undefined)
+        atoms.bodyStyles.body2Bold.fontFamily.setValue              (value ? value : undefined)
+        atoms.bodyStyles.body3.fontFamily.setValue                  (value ? value : undefined)
+        atoms.bodyStyles.body3Bold.fontFamily.setValue              (value ? value : undefined)
+        atoms.smallTextStyles.subtitle1.fontFamily.setValue         (value ? value : undefined)
+        atoms.smallTextStyles.subtitle2.fontFamily.setValue         (value ? value : undefined)
+        atoms.smallTextStyles.caption.fontFamily.setValue           (value ? value : undefined)
+        atoms.smallTextStyles.captionBold.fontFamily.setValue       (value ? value : undefined)
+        atoms.smallTextStyles.overline.fontFamily.setValue          (value ? value : undefined)
+        atoms.smallTextStyles.overlineLarge.fontFamily.setValue     (value ? value : undefined)
+        atoms.smallTextStyles.overlineExtraLarge.fontFamily.setValue(value ? value : undefined)
+        atoms.smallTextStyles.label1.fontFamily.setValue            (value ? value : undefined)
+        atoms.smallTextStyles.label1AllCaps.fontFamily.setValue     (value ? value : undefined)
+        atoms.smallTextStyles.label2.fontFamily.setValue            (value ? value : undefined)
+        atoms.smallTextStyles.label2AllCaps.fontFamily.setValue     (value ? value : undefined)
+        atoms.smallTextStyles.labelSmall.fontFamily.setValue        (value ? value : undefined)
+        atoms.smallTextStyles.callToAction.fontFamily.setValue      (value ? value : undefined)
+        atoms.smallTextStyles.callToActionSmall.fontFamily.setValue (value ? value : undefined)
+        atoms.smallTextStyles.small.fontFamily.setValue             (value ? value : undefined)
+        atoms.smallTextStyles.smallSemibold.fontFamily.setValue     (value ? value : undefined)
+        atoms.statStyles.stat.fontFamily.setValue                   (value ? value : undefined)
+
         if (FontWeightsUtil.isFontCommon(value)) {
             setPrimaryFontUncommon(false)
         } else {
@@ -187,6 +213,17 @@ export const FontSettingsAtom: React.FC<Props> = ({ atoms }) => {
         const value = event.target.value;
         setSecondaryFont(value);
         secondaryFontFamilyProperty.setValue(value);
+
+        // Update all Display and Header Fonts:
+        atoms.displayAndHeaderStyles.headerStyles[0].fontFamily.setValue (value ? value : undefined)
+        atoms.displayAndHeaderStyles.headerStyles[1].fontFamily.setValue (value ? value : undefined)
+        atoms.displayAndHeaderStyles.headerStyles[2].fontFamily.setValue (value ? value : undefined)
+        atoms.displayAndHeaderStyles.headerStyles[3].fontFamily.setValue (value ? value : undefined)
+        atoms.displayAndHeaderStyles.headerStyles[4].fontFamily.setValue (value ? value : undefined)
+        atoms.displayAndHeaderStyles.headerStyles[5].fontFamily.setValue (value ? value : undefined)
+        atoms.displayAndHeaderStyles.displayStyles[0].fontFamily.setValue(value ? value : undefined)
+        atoms.displayAndHeaderStyles.displayStyles[1].fontFamily.setValue(value ? value : undefined)
+
         if (FontWeightsUtil.isFontCommon(value)) {
             setSecondaryFontUncommon(false)
         } else {


### PR DESCRIPTION
- when the primary or secondary font is changed, update the relevant text style font accordingly

NOTE: Because of this, if a user changes an individual font, then goes back to the `fontSettings` atom, this will automatically overwrite their selection.