### PR TITLE
Fix hotlink underlining

### DIFF
--- a/code/src/ui/src/mui-a11y-tb/themes/Theme.css
+++ b/code/src/ui/src/mui-a11y-tb/themes/Theme.css
@@ -574,14 +574,17 @@ section {
   line-height: var(--caption-boldLineHeight) !important;
   letter-spacing: var(--caption-boldLetterSpacing) !important;
   text-transform: var(--caption-boldTextTransform) !important;
-  text-decoration:  var(--caption-boldTextDecoration) !important;
+  /* changed text-decoration away from being !important because it is messing up hotlink
+   * underlining
+   */
+  text-decoration:  var(--caption-boldTextDecoration)
 }
 
 .breadcrumbs .MuiBreadcrumbs-li a .fa-solid, .breadcrumbs .MuiBreadcrumbs-li a .fa-default {
   margin-right: var(--spacing-1);
 }
 
-.breadcrumbs .MuiBreadcrumbs-li a, .breadcrumbs .MuiBreadcrumbs-li:focus a, .breadcrumbs .MuiBreadcrumbs-li:active a {
+.breadcrumbs .MuiBreadcrumbs-li a.MuiLink-root, .breadcrumbs .MuiBreadcrumbs-li:focus a.MuiLink-root, .breadcrumbs .MuiBreadcrumbs-li:active a.MuiLink-root {
     color: var(--hotlink);
     text-decoration: var(--hotlink-decoration);
     text-decoration-color: var(--hotlink);

--- a/code/src/ui/src/mui-a11y-tb/themes/Theme.css
+++ b/code/src/ui/src/mui-a11y-tb/themes/Theme.css
@@ -679,6 +679,9 @@ section {
 .darkmode .breadcrumbs.white .MuiBreadcrumbs-separator {
   color: var(--dm-white) !important;
 }
+.darkmode .breadcrumbs.white .MuiBreadcrumbs-li:hover a {
+  text-decoration: none !important;
+}
 
 .darkmode .breadcrumbs:not(.back-breadcrumb).white .MuiBreadcrumbs-li:last-of-type .MuiTypography-root{
   color: var(--dm-white) !important;
@@ -694,6 +697,9 @@ section {
 }
 .darkmode .breadcrumbs:not(.back-breadcrumb).black .MuiBreadcrumbs-li:last-of-type .MuiTypography-root{
   color: var(--black) !important;
+}
+.darkmode .breadcrumbs.black .MuiBreadcrumbs-li:hover a {
+  text-decoration: none !important;
 }
 
 

--- a/code/src/ui/src/pages/DesignSystemPage.css
+++ b/code/src/ui/src/pages/DesignSystemPage.css
@@ -421,6 +421,10 @@
 .design-system-editor-right-content .darkmode .hotlink.visited {
     opacity: .7;
 }
+.design-system-editor-right-content .darkmode .hotlink.active,
+.design-system-editor-right-content.darkmode .hotlink.active {
+    text-decoration: var(--dm-hotlink-hover-decoration);
+}
 
 .design-system-editor-right-content .color-title {
     margin-top: 4px;

--- a/code/src/ui/src/pages/content/ColorModeSelector.tsx
+++ b/code/src/ui/src/pages/content/ColorModeSelector.tsx
@@ -13,8 +13,9 @@ export interface ColorModeSelector {
 
 export const ColorModeSelector: React.FC<ColorModeSelector> = ({ colorMode, setColorMode, children }) => {
 
-    // const backgroundColor:any = {default: "rgba(255,255,255,0)", black: "rgba(255,255,255,.5)", white: "rgba(0,0,0,.5)"}
+    const backgroundColor:any = {default: "rgba(255,255,255,0)", black: "rgba(255,255,255,.5)", white: "rgba(0,0,0,.5)"}
     // const color:any = {default: "var(--on-primary)", black: "black", white: "white"}
+    const style = {backgroundColor: backgroundColor[colorMode]};
 
     return (
         <>
@@ -26,7 +27,7 @@ export const ColorModeSelector: React.FC<ColorModeSelector> = ({ colorMode, setC
             <FormControlLabel value="white" control={<Radio size="small"/>} label="White"/>
         </RadioGroup>
         {children &&
-            <div className="color-mode-selector">
+            <div className="color-mode-selector" style={style}>
                 {children}
             </div>
         }


### PR DESCRIPTION
This fixes hotlinks issues with breadcrumbs, hotlinks and Heros in darkmode, especially with hover.

There appears to still be an issue with the Component->Colors->Hotlinks in dark mode.  I will open a separate issue for that.