### PR TITLE
Deploy to a11y-theme-builder.finos.org

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+a11y-theme-builder.finos.org


### PR DESCRIPTION
Following https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains , this PR adds a `CNAME` file with the definition of a11y-theme-builder.finos.org , so that - when the [build GitHub Action](https://github.com/finos/a11y-theme-builder/blob/main/.github/workflows/build.yml) runs `mkdocs gh-deploy`, the CNAME file will be copied into the `gh-pages` branch.