### PR TITLE
Add height options to button size 

### DIFF
--- a/code/src/ui/src/pages/molecules/ButtonsSmallMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/ButtonsSmallMolecule.tsx
@@ -30,7 +30,7 @@ export const ButtonsSmallMolecule: React.FC<Props> = ({ molecule, designSystem }
         <div>
             <HeadingSection item={molecule} title="Apply Styles">
                 <p>Configure settings that affect the appearance of small-size buttons</p>
-                <p>The height of the target area of the small button is set to the minimum target area you defined, but the visble button height can be set to your preference.</p>
+                <p>The height of the target area of the small button is set to the minimum target area you defined, but the visible button height can be set to your preference.</p>
             </HeadingSection>
             <ExampleSection>
                 <div className="buttonDemo">

--- a/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
@@ -37,6 +37,12 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
         buttonHeightProperty.setValue(value)
     }
 
+    // The selectables vary according to the gridSize and minHeight and so must be calculated here:
+    //  minHeight restricts the selectables to above that value
+    //  gridSize defines the values based on multiples of 3-7
+    //  44 and 48 must always be included
+    // Note: the value required is a float, which is then multiplied by the grid size to get the
+    //  value we see in the UI
     const renderButtonHeightSelectables = () => {
         var r = [];
         var selectables = [44/grid, 48/grid];
@@ -98,10 +104,10 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
                                 <NumberScaledSelectable property={molecule.secondaryBorder} units="px" scale={border}/>
                             </div>
                         </div>
-                      </div>
-                    </SettingsSection>
-                  <GeneratedCodeSection item={molecule} />
-               </ExampleSection>
+                    </div>
+                </SettingsSection>
+                <GeneratedCodeSection item={molecule} />
+            </ExampleSection>
         </div>
     )
 }

--- a/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
@@ -37,7 +37,7 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
         buttonHeightProperty.setValue(value)
     }
 
-    const renderMinTargetSelectables = () => {
+    const renderButtonHeightSelectables = () => {
         var r = [];
         var selectables = [44/grid, 48/grid];
         for (var j=3; j<=7; j++) {
@@ -76,9 +76,7 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
                                 <NumberScaledSelectable property={molecule.minWidth} units="px" scale={grid}/>
                             </div>
                             <div className="formRow top16">
-                                {/* --- Button Height Placeholder --- {buttonHeight} */}
-                                {/* <NumberScaledSelectable property={molecule.height} units="px" scale={grid}/> */}
-                                {renderMinTargetSelectables()}
+                                {renderButtonHeightSelectables()}
                             </div>
                             <div className="formRow">
                                 <NumberScaledSelectable property={molecule.radius} units="px" scale={grid} />

--- a/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) 2023 Discover Financial Services
  * Licensed under Apache-2.0 License. See License.txt in the project root for license information
  */
-import React, { useEffect } from 'react';
-import { Button } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { Button, FormControl, MenuItem, Select } from '@mui/material';
 import { DesignSystem, StandardButtons } from 'a11y-theme-builder-sdk';
 import { NumberScaledSelectable } from '../../components/editors/NumberScaledSelectable';
 import { StringSelectable } from '../../components/editors/StringSelectable';
@@ -24,8 +24,38 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
         console.log("ButtonsStandardMolecule mounted");
     }, [])
 
-    const grid = designSystem.atoms.gridSettings.grid.getValue();
+    const grid = designSystem.atoms.gridSettings.grid.getValue() || 8;
     const border = designSystem.atoms.borderSettings.baseBorderWidth.getValue();
+    const minTarget = designSystem.atoms.minimumTarget.minHeight.getValue();
+
+    const buttonHeightProperty = molecule.height
+    const [buttonHeight, setButtonHeight] = useState<number>((buttonHeightProperty.getValue() || 44/8));
+
+    async function handleButtonHeightChange(event: any): Promise<void> {
+        const value = parseFloat(event.target.value);
+        setButtonHeight(value);
+        buttonHeightProperty.setValue(value)
+    }
+
+    const renderMinTargetSelectables = () => {
+        var r = [];
+        var selectables = [44/grid, 48/grid];
+        for (var j=3; j<=7; j++) {
+            if (j !== 44/grid && j !== 48/grid) selectables.push(j)
+        }
+        selectables = selectables.sort()
+        if (!selectables) return;
+        for (var i=0; i<selectables.length; i++) {
+            var s = (selectables[i] * grid).toString() + "px";
+            r.push(<MenuItem key={s} value={selectables[i]}> {s} </MenuItem>)
+        }
+        return (
+            <FormControl sx={{m: 2, minWidth: 120}}>
+                <div className='subtitle'>{buttonHeightProperty.name}</div>
+                <Select sx={{width: "100px"}} label={buttonHeightProperty.name} labelId={`minHeightLabel`} value={buttonHeight} onChange={handleButtonHeightChange}>{r}</Select>
+            </FormControl>
+        )
+    }
 
     return (
         <div>
@@ -46,7 +76,9 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
                                 <NumberScaledSelectable property={molecule.minWidth} units="px" scale={grid}/>
                             </div>
                             <div className="formRow top16">
-                                <NumberScaledSelectable property={molecule.height} units="px" scale={grid}/>
+                                {/* --- Button Height Placeholder --- {buttonHeight} */}
+                                {/* <NumberScaledSelectable property={molecule.height} units="px" scale={grid}/> */}
+                                {renderMinTargetSelectables()}
                             </div>
                             <div className="formRow">
                                 <NumberScaledSelectable property={molecule.radius} units="px" scale={grid} />

--- a/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
+++ b/code/src/ui/src/pages/molecules/ButtonsStandardMolecule.tsx
@@ -26,7 +26,7 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
 
     const grid = designSystem.atoms.gridSettings.grid.getValue() || 8;
     const border = designSystem.atoms.borderSettings.baseBorderWidth.getValue();
-    const minTarget = designSystem.atoms.minimumTarget.minHeight.getValue();
+    const minTarget = designSystem.atoms.minimumTarget.minHeight.getValue() || 44;
 
     const buttonHeightProperty = molecule.height
     const [buttonHeight, setButtonHeight] = useState<number>((buttonHeightProperty.getValue() || 44/8));
@@ -46,6 +46,9 @@ export const ButtonsStandardMolecule: React.FC<Props> = ({ molecule, designSyste
         selectables = selectables.sort()
         if (!selectables) return;
         for (var i=0; i<selectables.length; i++) {
+            if (selectables[i] * grid < minTarget) {
+                continue;
+            }
             var s = (selectables[i] * grid).toString() + "px";
             r.push(<MenuItem key={s} value={selectables[i]}> {s} </MenuItem>)
         }


### PR DESCRIPTION
ThemBuilder changes for https://github.com/finos/a11y-theme-builder/issues/601:
- buttonHeight values are based on multiples of the gridSize
- buttonHeight values are restricted by the minTarget

This change will break ThemeBuilder until its corresponding SDK PR is merged (https://github.com/finos/a11y-theme-builder-sdk/pull/141)