### PR TITLE
finos/a11y-theme-builder#742: changing bookworm-slim version for Dock…

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - 'main'
       - 'dev'
+      - 'fix-docker-scans'
     paths:
       - 'code/src/**'
       - 'code/package.json'

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - 'main'
       - 'dev'
-      - 'fix-docker-scans'
     paths:
       - 'code/src/**'
       - 'code/package.json'

--- a/code/Dockerfile
+++ b/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.18-bookworm-slim
+FROM node:18.19-bookworm-slim
 RUN node -v
 # Copy source
 RUN mkdir $HOME/code


### PR DESCRIPTION
…er image to potentially fix a vulnerability

Changed base image from node:18.18-bookworm-slim to node:18.19-bookworm-slim to get rid of https://github.com/advisories/GHSA-96fh-9q43-rmjh from the Docker scans.