### PR TITLE
Adding link to demo website on website top menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,4 +194,6 @@ nav:
     - glossary/index.md
   - References:
     - references/index.md
+  - Demo:
+    - https://try.a11y-theme-builder.finos.org/
     


### PR DESCRIPTION
Adding the link to the demo website - https://try.a11y-theme-builder.finos.org/

I wonder if this is the right syntax, and if there are better ways to do this in mkdocs; maybe there is a better way to show it, like ribbons?