### PR TITLE
Update `DEV_GUIDE.md` to Include `dev` Branch Instructions

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -36,6 +36,18 @@ where:
 * `<WORKSPACE>` is path to the local folder where you have created a copy of the GitHub repository.
 * `<YOUR-ORG>` is the name of your GitHub account or personal GitHub organization.
 
+### Set Upstream Branch
+
+After cloning the repository, it's recommended to set the `dev` branch as the upstream branch for development. 
+This is a common practice in many development workflows where all the development happens in the `dev` branch and then it's merged into the `main` branch when it's ready for production. 
+
+Here's how you can do it:
+
+```bash
+git checkout dev
+git branch --set-upstream-to=origin/dev
+```
+
 ### Quick and Easy
 Building and running the application using `Docker` can be achieved in a few simple steps, which all assume a `/code` as the working directory.
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -38,8 +38,7 @@ where:
 
 ### Set Upstream Branch
 
-After cloning the repository, it's recommended to set the `dev` branch as the upstream branch for development. 
-This is a common practice in many development workflows where all the development happens in the `dev` branch and then it's merged into the `main` branch when it's ready for production. 
+After cloning the repository, it's recommended to set the `dev` branch as the upstream branch for development.
 
 Here's how you can do it:
 
@@ -47,6 +46,8 @@ Here's how you can do it:
 git checkout dev
 git branch --set-upstream-to=origin/dev
 ```
+
+This is a common practice in many development workflows where all the development happens in the `dev` branch and then it's merged into the `main` branch when it's ready for production.
 
 ### Quick and Easy
 Building and running the application using `Docker` can be achieved in a few simple steps, which all assume a `/code` as the working directory.


### PR DESCRIPTION
Fixes #850.

This PR introduces a new section in the `DEV_GUIDE.md` that provides instructions on setting the `dev` branch as the upstream branch for development. This change was suggested in the issue labeled documentation enhancement in `DEV_GUIDE.md`.