### PR TITLE
chore: made design card clickable with hover and focus states

### DIFF
--- a/code/src/ui/src/components/SystemCard.tsx
+++ b/code/src/ui/src/components/SystemCard.tsx
@@ -3,7 +3,7 @@
  * Licensed under Apache-2.0 License. See License.txt in the project root for license information
  */
 import { Card, CardContent, CardHeader, IconButton, Box, Menu, MenuItem, Divider, Button } from "@mui/material";
-import React, { useState, MouseEvent, ReactNode } from "react";
+import React, { useState, MouseEvent } from "react";
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { FormattedTime, FormattedDate } from "react-intl";
 import { ThemeBuilder } from "@finos/a11y-theme-builder-sdk";
@@ -22,6 +22,7 @@ export const SystemCard: React.FC<Props> = ({themeBuilder, designSystems, design
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: MouseEvent<HTMLElement>) => {
+        event.stopPropagation();
         setAnchorEl(event.currentTarget);
     };
     const [doCopy, setDoCopy] = useState(false);
@@ -173,7 +174,10 @@ export const SystemCard: React.FC<Props> = ({themeBuilder, designSystems, design
 
     return (
         <div className="system-card">
-            <Card>
+            <Card 
+                className= "clickable"
+                onClick={() => handleClose("load")}
+            >
                 <CardHeader
                     action={
                         <IconButton
@@ -189,10 +193,7 @@ export const SystemCard: React.FC<Props> = ({themeBuilder, designSystems, design
                         </IconButton>
                     }
                     title={
-                        <h5
-                            onClick={() => handleClose("load")}
-                            style={{cursor: "pointer"}}
-                        >{name}</h5>
+                        <h5>{name}</h5>
                     }
                     subheader={
                         <div className="date caption quiet">


### PR DESCRIPTION
Fixes #676 


## Fix Summary
- Added hover and focus state to the Design System card
- Added a click event to the card so it redirects and loads the design system
- Made sure that the setting iconButton function is still being preserved and the card event doesn't bubble to the child event
- Removed the `onClick` event that was in the card title since its no longer needed

## Video Demo

### Before

[screen-capture (1).webm](https://github.com/finos/a11y-theme-builder/assets/38161296/fc4e42ca-fa07-4b80-a527-6c86acf015fc)


### After

[screen-capture.webm](https://github.com/finos/a11y-theme-builder/assets/38161296/194c1891-097d-4e7b-a62d-033519f78004)
