### PR TITLE
Update MAINTAINERS.md to refine responsibilities and enable LF Badging changes

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,20 @@
-The success of this project is the direct result of contributions across two (2)project related repositories:
+The success of this project is the direct result of contributions across two
+(2) project related repositories:
 
 1. [a11y-theme-builder](https://github.com/finos/a11y-theme-builder) (TB)
 2. [a11y-theme-builder-sdk](https://github.com/finos/a11y-theme-builder-sdk) (SDK)
+
+Contributors listed below were part of the original vision and efforts to create
+and publish this project.
+
+Maintainers listed below are also key contributors, but have the additional 
+responsibilities of collaborating on project direction, community growth, 
+monitoring the FINOS Slack channels for the project, nominating additoinal 
+maintainers, and nominating community members for various badges that can be 
+awarded from the Linux Foundation based on contribution to the project.
+
+See the Project Contribution Guide for more details on badges and the badging
+process.
 
 | Individual | TB | SDK |
 | --- | --- | --- | 


### PR DESCRIPTION
Changes needed to enable Linux Foundation badging and refine the responsibilities of core maintainers.