### PR TITLE
finos:#924 Ensure Typography Font Settings selects are properly labeled

### DIFF
--- a/code/src/ui/src/pages/atoms/typography/FontSettingsAtom.tsx
+++ b/code/src/ui/src/pages/atoms/typography/FontSettingsAtom.tsx
@@ -227,9 +227,9 @@ export const FontSettingsAtom: React.FC<Props> = ({ atoms }) => {
 
         return (
             <FormControl sx={{m: textFieldMb, minWidth: textFieldWidth}}>
-                <div className='subtitle'><b>{primaryFontFamilyProperty.name}</b></div>
-                <div className='body1' style={{fontWeight:"normal"}}>{primaryFontDescription}</div>
-                <Select id="primaryFontSelect" value={primaryFont} onChange={handlePrimaryFontChange}>
+                <div id="primaryFontLabel" className='subtitle'><b>{primaryFontFamilyProperty.name}</b></div>
+                <div id="primaryFontDescription" className='body1' style={{fontWeight:"normal"}}>{primaryFontDescription}</div>
+                <Select id="primaryFontSelect" labelId="primaryFontLabel" aria-describedby="primaryFontDescription" value={primaryFont} onChange={handlePrimaryFontChange}>
                     {r}
                 </Select>
             </FormControl>
@@ -245,9 +245,9 @@ export const FontSettingsAtom: React.FC<Props> = ({ atoms }) => {
 
         return (
             <FormControl sx={{m: textFieldMb, minWidth: textFieldWidth}}>
-                <div className='subtitle'><b>{secondaryFontFamilyProperty.name}</b></div>
-                <div className='body1' style={{fontWeight:"normal"}}>{secondaryFontDescription}</div>
-                <Select id="secondaryFontSelect" value={secondaryFont} onChange={handleSecondaryFontChange}>
+                <div id="secondaryFontLabel" className='subtitle'><b>{secondaryFontFamilyProperty.name}</b></div>
+                <div id="secondaryFontDescription" className='body1' style={{fontWeight:"normal"}}>{secondaryFontDescription}</div>
+                <Select id="secondaryFontSelect" labelId="secondaryFontLabel" aria-describedby="secondaryFontDescription" value={secondaryFont} onChange={handleSecondaryFontChange}>
                     {r}
                 </Select>
             </FormControl>


### PR DESCRIPTION
Ensure all select fields in the Typography Font Settings page have proper labels to improve accessibility. This fixes issue #924.

Proposed Solution

Update the select fields in the Typography Font Settings page to include the necessary label attributes. This will ensure that the select fields have accessible names, as required by WCAG 4.1.2.

To test, run Accessibility Insights For Web's FastPass tool and ensure that the issue mentioned in #924 is no longer reproducible in the deploy preview.