### PR TITLE
finos#923: [TB] Fix WCAG 4.1.2 issue with Font Settings Slider

### DIFF
--- a/code/src/ui/src/components/modals/ModalFontEdit.tsx
+++ b/code/src/ui/src/components/modals/ModalFontEdit.tsx
@@ -206,13 +206,15 @@ const ModalFontEdit: React.FC<Props> = ({isOpen, onCancel, designSystem, textKey
                             </Alert>}
                             <br/>
                             <FormControl sx={{m: 2, minWidth: 500}}>
-                                <label className="label-1">
+                                <label id="fontSizeLabel" className="label-1">
                                     Font Size:
                                 </label>
                                 <div className="caption">
                                     Size:&nbsp;<span>{fontSize}px</span>
                                 </div>
                                 <Slider
+                                    aria-labelledby="fontSizeLabel"
+                                    aria-valuetext={`${fontSize}px`}
                                     value={fontSize}
                                     onChange={handleFontSizeChange}
                                     min={fontSizeProperty.min}
@@ -233,13 +235,14 @@ const ModalFontEdit: React.FC<Props> = ({isOpen, onCancel, designSystem, textKey
                             </div>
                             <br/>
                             <FormControl sx={{m: 2, minWidth: 500}}>
-                                <label className="label-1">
+                                <label id="characterSpacingLabel" className="label-1">
                                     Character Spacing:
                                 </label>
                                 <div className="caption">
                                     Spacing: <span>{charSpacing}</span>
                                 </div>
                                 <Slider
+                                    aria-labelledby='characterSpacingLabel'
                                     value={charSpacing}
                                     onChange={handleCharSpacingChange}
                                     min={charSpacingProperty.min}


### PR DESCRIPTION
Ensures every form element in the Settings Slider has a label to comply with WCAG 4.1.2. This pull request includes the following changes:

- Added `aria-labelledby` attribute to the Font Size Slider to associate it with the label element.
- Added `aria-valuetext` to the Font Size Slider to associate the pixels with the slider.
- Added `aria-labelledby` attribute to the Character Spacing Slider to associate it with the label element.

Fixes #923