### PR TITLE
[TB] Multiple instances, hardcoded ids/labelids in Selectable editors causing accessibility issues 

### DIFF
--- a/code/src/ui/src/components/editors/NumberProperty.tsx
+++ b/code/src/ui/src/components/editors/NumberProperty.tsx
@@ -5,6 +5,7 @@
 import React, { useState, useEffect } from 'react';
 import { InputLabel, TextField, InputAdornment } from '@mui/material';
 import { PropertyPixel, PropertyTime } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface NumberProps {
     property: PropertyTime | PropertyPixel;
@@ -54,11 +55,15 @@ export const NumberProperty: React.FC<NumberProps> = ({
 
     const _onChange = customHandleChange || handleChange;
 
+    const idSuffix = uuidv4();
+    const labelId = `numberPropertyLabel-${idSuffix}`;
+    const textFieldId = `numberPropertyTextField-${idSuffix}`;
+
     return (
         <div>
             <InputLabel
-                htmlFor="numberPropertyTextField"
-                id="numberPropertyLabel"
+                htmlFor={textFieldId}
+                id={labelId}
             >
                 {children || property.name}
             </InputLabel>
@@ -66,7 +71,7 @@ export const NumberProperty: React.FC<NumberProps> = ({
                 <div style={{ fontWeight: 'normal' }}>{description}</div>
             )}
             <TextField
-                id="numberPropertyTextField"
+                id={textFieldId}
                 InputProps={
                     units
                         ? {

--- a/code/src/ui/src/components/editors/NumberScaledSelectable.tsx
+++ b/code/src/ui/src/components/editors/NumberScaledSelectable.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { InputLabel, MenuItem, Select } from '@mui/material';
 import { PropertyPixelSelectable } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface PixelProps {
     property: PropertyPixelSelectable;
@@ -49,17 +50,20 @@ export const NumberScaledSelectable: React.FC<PixelProps> = ({
             </MenuItem>
         );
     }
+    const idSuffix = uuidv4();
+    const labelId = `pixelSelectLabel-${idSuffix}`;
+    const selectId = `pixelSelect-${idSuffix}`;
     return (
         <div>
-            <InputLabel id="pixelSelectLabel">
+            <InputLabel id={labelId}>
                 {children || property.name}
             </InputLabel>
             {description && (
                 <div style={{ fontWeight: 'normal' }}>{description}</div>
             )}
             <Select
-                id="pixelSelect"
-                labelId="pixelSelectLabel"
+                id={selectId}
+                labelId={labelId}
                 value={value}
                 onChange={handleChange}
             >

--- a/code/src/ui/src/components/editors/NumberSelectable.tsx
+++ b/code/src/ui/src/components/editors/NumberSelectable.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { InputLabel, MenuItem, Select } from '@mui/material';
 import { PropertyPixelSelectable } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface PixelProps {
     property: PropertyPixelSelectable;
@@ -42,17 +43,20 @@ export const NumberSelectable: React.FC<PixelProps> = ({
             </MenuItem>
         );
     }
+    const idSuffix = uuidv4();
+    const labelId = `pixelSelectLabel-${idSuffix}`;
+    const selectId = `pixelSelect-${idSuffix}`;
     return (
         <div>
-            <InputLabel id="pixelSelectLabel">
+            <InputLabel id={labelId}>
                 {children || property.name}
             </InputLabel>
             {description && (
                 <div style={{ fontWeight: 'normal' }}>{description}</div>
             )}
             <Select
-                id="pixelSelect"
-                labelId="pixelSelectLabel"
+                id={selectId}
+                labelId={labelId}
                 value={value}
                 onChange={handleChange}
             >

--- a/code/src/ui/src/components/editors/StringCategorySelectable.tsx
+++ b/code/src/ui/src/components/editors/StringCategorySelectable.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { InputLabel, ListSubheader, MenuItem, Select } from '@mui/material';
 import { PropertyStringCategorySelectable } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface StringProps {
     property: PropertyStringCategorySelectable;
@@ -41,12 +42,15 @@ export const StringCategorySelectable: React.FC<StringProps> = ({
         property: PropertyStringCategorySelectable,
         label: string
     ) => {
+        const idSuffix = uuidv4();
+        const labelId = `stringSelectLabel-${idSuffix}`;
+        const selectId = `stringSelect-${idSuffix}`;
         return (
             <div>
-                <InputLabel id="stringSelectLabel">{label}</InputLabel>
+                <InputLabel id={labelId}>{label}</InputLabel>
                 <Select
-                    id="stringSelect"
-                    labelId="stringSelectLabel"
+                    id={selectId}
+                    labelId={labelId}
                     value={title}
                     onChange={handleChange}
                 >

--- a/code/src/ui/src/components/editors/StringProperty.tsx
+++ b/code/src/ui/src/components/editors/StringProperty.tsx
@@ -5,6 +5,7 @@
 import React, { useState, useEffect } from 'react';
 import { InputLabel, TextField, InputAdornment } from '@mui/material';
 import { Property } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface NumberProps {
     property: Property<string>;
@@ -49,11 +50,15 @@ export const StringProperty: React.FC<NumberProps> = ({
 
     const _onChange = customHandleChange || handleChange;
 
+    const idSuffix = uuidv4();
+    const labelId = `stringPropertyLabel-${idSuffix}`;
+    const textFieldId = `stringPropertyTextField-${idSuffix}`;
+
     return (
         <div>
             <InputLabel
-                htmlFor="stringPropertyTextField"
-                id="stringPropertyLabel"
+                htmlFor={textFieldId}
+                id={labelId}
             >
                 {children || property.name}
                 {description && (
@@ -61,7 +66,7 @@ export const StringProperty: React.FC<NumberProps> = ({
                 )}
             </InputLabel>
             <TextField
-                id="stringPropertyTextField"
+                id={textFieldId}
                 InputProps={
                     units
                         ? {

--- a/code/src/ui/src/components/editors/StringSelectable.tsx
+++ b/code/src/ui/src/components/editors/StringSelectable.tsx
@@ -14,6 +14,7 @@ import {
     Select,
 } from '@mui/material';
 import { PropertyStringSelectable } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface StringProps {
     property: PropertyStringSelectable;
@@ -41,12 +42,15 @@ export const StringSelectable: React.FC<StringProps> = ({
         property: PropertyStringSelectable,
         label: string
     ) => {
+        const idSuffix = uuidv4();
+        const labelId = `stringSelectLabel-${idSuffix}`;
+        const selectId = `stringSelect-${idSuffix}`;
         return (
             <div>
-                <InputLabel id="stringSelectLabel">{label}</InputLabel>
+                <InputLabel id={labelId}>{label}</InputLabel>
                 <Select
-                    id="stringSelect"
-                    labelId="stringSelectLabel"
+                    id={selectId}
+                    labelId={labelId}
                     value={title}
                     onChange={handleChange}
                 >
@@ -60,13 +64,15 @@ export const StringSelectable: React.FC<StringProps> = ({
         property: PropertyStringSelectable,
         label: string
     ) => {
+        const idSuffix = uuidv4();
+        const labelId = `underline-hotlinks-lightmode-radio-buttons-group-${idSuffix}`;
         return (
             <FormControl>
-                <FormLabel id="underline-hotlinks-lightmode-radio-buttons-group">
+                <FormLabel id={labelId}>
                     {label}
                 </FormLabel>
                 <RadioGroup
-                    aria-labelledby="hotlinks-lightmode-radio-buttons-group"
+                    aria-labelledby={labelId}
                     name="controlled-radio-buttons-group"
                     value={title}
                     onChange={handleChange}


### PR DESCRIPTION
Fixes #953.

Ensures all selectable editors have a unique id where IDs are being used. This allows each component with an id to have a correct accessible name. When duplicate IDs were used, accessible names could not be properly identified.

To test, run axe-devtools or Accessibility Insights for Web on a page that uses a Selectable component. Verify that aria-input-field-name error does not come up when running automated checks.