### PR TITLE
[TB] Ensure color select has unique id and accessible name

### DIFF
--- a/code/src/ui/src/components/ColorPairSelect.tsx
+++ b/code/src/ui/src/components/ColorPairSelect.tsx
@@ -16,6 +16,7 @@ import {
     EventType,
     PropertyColorPair,
 } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 import { ColorShade } from './ColorShade';
 import './ColorPairSelect.css';
 
@@ -89,15 +90,20 @@ export const ColorPairSelect: React.FC<Props> = ({ value, label }) => {
     };
 
     if (value) {
+        const idSuffix = uuidv4();
+        const selectId = `outlined-select-${idSuffix}`
+        const labelId = `outlined-select-label-${idSuffix}`
         return (
             <div>
                 {label && (
-                    <InputLabel className="caption" htmlFor="outlined-select">
+                    <InputLabel className="caption" id={labelId} htmlFor={selectId}>
                         {label}
                     </InputLabel>
                 )}
                 <Select
                     label=""
+                    labelId={label && labelId}
+                    id={selectId}
                     onChange={handleColorChange}
                     displayEmpty={true}
                     defaultValue=""

--- a/code/src/ui/src/components/ColorSelect.tsx
+++ b/code/src/ui/src/components/ColorSelect.tsx
@@ -16,6 +16,7 @@ import {
     PropertyColorShade,
     Shade,
 } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 import { ColorShade } from '../components/ColorShade';
 import './ColorSelect.css';
 
@@ -178,14 +179,19 @@ export const ColorSelect: React.FC<Props> = ({
     //  Mui Select into a grid.  Each menu item in the list will be positioned
     //  in the grid based on where that shade was in the selectableValuesGrid
     if (value) {
+        const idSuffix = uuidv4();
+        const selectId = `outlined-select-${idSuffix}`
+        const labelId = `outlined-select-label-${idSuffix}`
         return (
             <div>
                 {label && (
-                    <InputLabel className="caption" htmlFor="outlined-select">
+                    <InputLabel className="caption" id={labelId} htmlFor={selectId}>
                         {label}
                     </InputLabel>
                 )}
                 <Select
+                    labelId={label && labelId}
+                    id={selectId}
                     onChange={handleColorChange}
                     displayEmpty={true}
                     value={_selectedValue}

--- a/code/src/ui/src/components/ColorSelectTitled.tsx
+++ b/code/src/ui/src/components/ColorSelectTitled.tsx
@@ -17,6 +17,7 @@ import {
     PropertyTitledShade,
     TitledShade,
 } from '@finos/a11y-theme-builder-sdk';
+import { v4 as uuidv4 } from 'uuid';
 import { ColorShade } from './ColorShade';
 import './ColorSelectTitled.css';
 
@@ -100,15 +101,20 @@ export const ColorSelectTitled: React.FC<Props> = ({ value, label }) => {
     };
 
     if (value) {
+        const idSuffix = uuidv4();
+        const selectId = `outlined-select-${idSuffix}`;
+        const labelId = `outlined-select-label-${idSuffix}`;
         return (
             <div>
                 {label && (
-                    <InputLabel className="caption" htmlFor="outlined-select">
+                    <InputLabel className="caption" id={labelId} htmlFor={selectId}>
                         {label}
                     </InputLabel>
                 )}
                 <Select
                     label="Primary"
+                    labelId={label && labelId}
+                    id={selectId}
                     onChange={handleColorChange}
                     displayEmpty={true}
                     defaultValue=""


### PR DESCRIPTION
This pull request fixes issue #952 by adding unique ids and accessible names to the color select components in the A11y ThemeBuilder. The ids are generated using the uuid library to ensure uniqueness. This improves the accessibility of the color select components.