### PR TITLE
finos/a11y-theme-builder#946: fix color picker hex value text not con…

### DIFF
--- a/code/src/ui/src/components/ColorShade.css
+++ b/code/src/ui/src/components/ColorShade.css
@@ -1,4 +1,4 @@
-<<<<<<< Updated upstream ======= .color-block {
+.color-block {
     display: inline-block;
     font-size: 11px;
     width: 96px;
@@ -29,6 +29,6 @@ li .Hex {
     text-align: center !important;
 }
 
->>>>>>>Stashed changes .swatch-details.active {
+.swatch-details.active {
     display: block;
 }

--- a/code/src/ui/src/pages/atoms/ColorPaletteAtom.tsx
+++ b/code/src/ui/src/pages/atoms/ColorPaletteAtom.tsx
@@ -195,7 +195,7 @@ export const ColorPaletteAtom: React.FC<Props> = ({
                                 sx={{
                                     backgroundColor: `${_blockPickerColor}`,
                                     input: {
-                                        color: `${_blockPickerOnColor}`,
+                                        color: `${_blockPickerOnColor} !important`,
                                     },
                                 }}
                             />


### PR DESCRIPTION
…trasting with background enough if a dark color is selected.

We were actually already doing the work to get the proper on-color for the selected color (which appears in the background of the input field).  But the style was being overruled.  So I added !important to fix this.  Since this rule is applied directly to the color picker input, it should be safe.