### PR TITLE
This PR is in order to resolve: [TB] Copying a theme no longer works #1124 

### DIFF
--- a/code/src/ui/src/components/SystemCard.tsx
+++ b/code/src/ui/src/components/SystemCard.tsx
@@ -94,8 +94,8 @@ export const SystemCard: React.FC<Props> = ({
                     console.log('Design system already exists');
                 } else {
                     if (themeBuilder) {
-                        //const ds = await themeBuilder.getDesignSystem(name);
-                        //const nds = await ds.copy(dest);
+                        const ds = await themeBuilder.getDesignSystem(name);
+                        const nds = await ds.copy(dest);
                     }
                     setTimeout(function () {
                         refresh();


### PR DESCRIPTION
it think it was turned into comment because of lint changes we did last year in july

@aaronreed708 
you may highlight if I am wrong and it was done intentionally may be ? 

<img width="1555" height="903" alt="image" src="https://github.com/user-attachments/assets/6a5a7a88-b5a7-4974-afcc-3a39427eb915" />

re deploying commented code 

resolving issue #1124 